### PR TITLE
Adding and refactoring flags for power armor items

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Advanced_Technologies/at_power_armor.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Advanced_Technologies/at_power_armor.json
@@ -33,7 +33,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "OVERSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "OVERSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "power_armor_crusader_on",
@@ -43,7 +43,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "modern crusader power armor (active)", "str_pl": "modern crusader power armors (active)" },
     "description": "This armor was manufactured and was owned by a cult of basically super christians and if you couldnt tell they wanted another crusade.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "OVERSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_crusader",
     "use_action": {
@@ -90,18 +90,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "modern crusader power armor helm (active)", "str_pl": "modern crusader power armor helms (active)" },
     "description": "While it may look like an old crusader helm complete with the cross shaped opening in the front the lights in the darkness tells it is not just any helm.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "OVERSIZE",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "PARTIAL_DEAF",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "power_armor_helmet_crusader",

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Biosynthetic_Robot_Mod_jm/gb_armor.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Biosynthetic_Robot_Mod_jm/gb_armor.json
@@ -31,7 +31,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "gkb_chinese_armor_on",
@@ -41,7 +41,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Chinese power armor (active)", "str_pl": "Chinese power armors (active)" },
     "description": "Developed after the groundbreaking creation of power armor by the United States, the Type-13 combat exoskeleton was China's attempt at making an equivalent to the United States. Development of these suits of protection were significantly rushed though, and are often inferior to their American counterparts, if a bit lighter to wear.  It is currently turned on, activate it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "gkb_chinese_armor",
     "use_action": {
@@ -85,7 +85,7 @@
       "active": true
     },
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
   },
   {
     "id": "gkb_chinese_armor_helmet_on",
@@ -95,17 +95,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Chinese power armor helmet (active)", "str_pl": "Chinese power armor helmets (active)" },
     "description": "A fully enclosed combat helmet for hazardous environments and combat zones the Chinese military expected to find itself in, this was designed to fit with a powered exoskeleton, using cameras to expand visual range.  In practice, the cameras were unreliable and easily fouled.  The environmental controls function best with direct-skin contact.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "PARTIAL_DEAF",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "gkb_chinese_armor_helmet",
@@ -149,7 +139,7 @@
       "active": true
     },
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "POWERARMOR_EXTERNAL", "STURDY", "SUN_GLASSES" ],
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "STURDY", "SUN_GLASSES" ],
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 1 } ] } ] }
   },
   {
@@ -160,15 +150,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Chi Industries combat headset (active)", "str_pl": "Chi Industries combat headsets (active)" },
     "description": "The Chi Industries combat headset is a target aquisition system designed for use with the Chi-93b gaiden power suit. Lacks a great deal of ballistic effectiveness due to lack of coverage around the head.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATCH",
-      "STURDY",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "gkb_chi_powarmor_helmet",
@@ -214,7 +196,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
     "relic_data": {
       "passive_effects": [
         {
@@ -238,7 +220,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Chi Industries power armor (active)", "str_pl": "Chi Industries power armors (active)" },
     "description": "This rather unique variant of power armor was developed by the famed Japanese robot company, Chi Industries. Known as the Chi-93b Gaiden power suit, this armor sacrifices protection for increased manuevarability and decreased cost. Curiously, the armor comes in two sex-based variants: an armored anime-esque battledress for women, and a more conventional form of power armor for men.  It is currently turned on, activate it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "gkb_chi_powarmor",
     "use_action": {
@@ -284,7 +266,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "gkb_xedra_exsuit_on",
@@ -294,7 +276,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "XEDRA excursion suit (active)", "str_pl": "XEDRA excursion suits (active)" },
     "description": "Developed by XEDRA for use in the most hazardous environments, the excursion suit is a seldom seen, and even more seldom used power armor unit. Unlike most power armor units, the excursion suit features a relatively large internal storage area for jaunts across the New England exclusion zone, or perhaps areas more extra-terrestrial in nature.  It is currently turned on, activate it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "gkb_xedra_exsuit",
     "use_action": {
@@ -338,7 +320,7 @@
       "active": true
     },
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ],
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ],
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 1 } ] } ] }
   },
   {
@@ -349,15 +331,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "XEDRA excursion suit helmet (active)", "str_pl": "XEDRA excursion suit helmets (active)" },
     "description": "A fully enclosed combat helmet for hazardous environments, features a large transparent superalloy visor similar to those found on spacesuits.  The environmental controls function best with direct-skin contact. It's target-acquisition visor slightly improves the user's perception.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATCH",
-      "STURDY",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "gkb_xedra_exsuit_helmet",

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Fallout_CDDA_BrightNights/Items/armor_power.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Fallout_CDDA_BrightNights/Items/armor_power.json
@@ -30,7 +30,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "power_armor_t51_on",
@@ -40,7 +40,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "T-51 power armor (on)", "str_pl": "T-51 power armors (on)" },
     "description": "The T-51b powered infantry armor is designed with the latest passive defense features for both civilian and military disturbances. It requires power.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_t51",
     "use_action": {
@@ -83,7 +83,7 @@
       "need_worn": true,
       "active": true
     },
-    "flags": [ "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
   },
   {
     "id": "power_armor_helmet_t51_on",
@@ -93,17 +93,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "T-51b power helmet (active)", "str_pl": "T-51b power helmets (active)" },
     "description": "A basic helmet, designed for use with the the T-51b Power Helmet.  Offers excellent protection from both attacks and environmental hazards.  Like all DoubleTech power armor, the control and climate-regulation systems require direct skin contact.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "PARTIAL_DEAF",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "power_armor_helmet_t51",
@@ -149,7 +139,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "power_armor_t45_on",
@@ -159,7 +149,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "T-45 Power armor (on)", "str_pl": "T-45 Power armors (on)" },
     "description": "A suit of T-45D power armor, T-51's weaker cousin, T-45 is bulky, but still effective. It requires power.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_t45",
     "use_action": {
@@ -202,7 +192,7 @@
       "need_worn": true,
       "active": true
     },
-    "flags": [ "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "SUN_GLASSES" ]
   },
   {
     "id": "power_armor_helmet_t45_on",
@@ -212,17 +202,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "T-45 power helmet (active)", "str_pl": "T-45 power helmets (active)" },
     "description": "A T-45 power helmet. Bulky, but it works",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "PARTIAL_DEAF",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "power_armor_helmet_t45",
@@ -268,7 +248,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "power_armor_x01_on",
@@ -278,7 +258,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Enclave X-01 Power Armor (on)", "str_pl": "Enclave X-01 Power Armors (on)" },
     "description": "One of the enclave's myriad of power armor models, the X-01 is the first model, used by the Enclave elite.  It requires power.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_x01",
     "use_action": {
@@ -321,7 +301,7 @@
       "need_worn": true,
       "active": true
     },
-    "flags": [ "WATERPROOF", "STURDY", "SUN_GLASSES" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "WATERPROOF", "STURDY", "SUN_GLASSES" ]
   },
   {
     "id": "power_armor_helmet_x01_on",
@@ -331,18 +311,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "enclave x-01 power armor helmet (active)", "str_pl": "enclave x-01 power armor helmets (active)" },
     "description": "An enclave power armor helmet. It looks quite menacing.",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "WATERPROOF",
-      "TRADER_AVOID",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "THERMOMETER",
-      "SUN_GLASSES",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "revert_to": "power_armor_helmet_x01",
     "use_action": {

--- a/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/Civilianpowerarmor/power_armor.json
+++ b/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/Civilianpowerarmor/power_armor.json
@@ -55,7 +55,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ]
   },
   {
     "id": "power_armor_Civilian_on",
@@ -65,7 +65,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "Commercial power armor (active)", "str_pl": "Commercial power armors (active)" },
     "description": "A suit of DoubleTech Power Armor, Mk. I-C.  This model Is Made For Commercial Use, This Model Was Very Common To See On Rich Members Of society. Like all DoubleTech power armor, the control and climate-regulation systems require direct skin contact.  It is currently turned on, activate it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_Civilian",
     "use_action": {

--- a/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/Mutated-Arsenal/Mutated_arsenal.json
+++ b/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods/Mutated-Arsenal/Mutated_arsenal.json
@@ -30,7 +30,7 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "POWERARMOR_EXO", "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "power_armor_mutant_on",
@@ -40,7 +40,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "mutant power armor (active)", "str_pl": "mutant power armors (active)" },
     "description": "A modified suit of DoubleTech Power Armor, Mk. II-H.Designed to be used with mutated anatomy in the _REDACTED_ project,it stayed a proof of concept since the _REDACTED_ lifecycle was too short.  It is currently turned on, activate it to turn it off.",
-    "flags": [ "POWERARMOR_EXO", "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "ALLOWS_NATURAL_ATTACKS", "CLIMATE_CONTROL", "TRADER_AVOID" ],
+    "extend": { "flags": [ "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_mutant",
     "use_action": {
@@ -75,7 +75,7 @@
     "material_thickness": 12,
     "environmental_protection": 16,
     "qualities": [ [ "GLARE", 2 ] ],
-    "flags": [ "POWERARMOR_EXTERNAL", "OVERSIZE", "VARSIZE", "WATCH", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "THERMOMETER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXTERNAL", "OVERSIZE", "VARSIZE", "WATERPROOF", "STURDY", "PARTIAL_DEAF", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "power_armor_helmet_mutant_on",
@@ -85,19 +85,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "heavy power armor helmet (active)", "str_pl": "heavy power armor helmets (active)" },
     "description": "A power armor helmet designed for use with the modified DoubleTech Power Armor, Mk. II-H.Like its accompanying suit, it was never mass produced since the lifespan of _REDACTED_ soldiers was too short, so only the blueprints remained .",
-    "flags": [
-      "POWERARMOR_EXTERNAL",
-      "OVERSIZE",
-      "VARSIZE",
-      "WATCH",
-      "WATERPROOF",
-      "STURDY",
-      "PARTIAL_DEAF",
-      "THERMOMETER",
-      "ALLOWS_NATURAL_ATTACKS",
-      "CLIMATE_CONTROL",
-      "TRADER_AVOID"
-    ],
+    "extend": { "flags": [ "WATCH", "THERMOMETER", "CLIMATE_CONTROL", "TRADER_AVOID" ] },
     "power_draw": 500000,
     "qualities": [ [ "GLARE", 2 ] ],
     "revert_to": "power_armor_helmet_mutant",


### PR DESCRIPTION
Working on [1786](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1786) reminded me that I didn't fully catch Kenan's pack up to the final iteration of the power armor overhaul [1505](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1786)

It was worse than I thought, I had assumed I'd simply forgotten to put in the `NAT_UPS` flag, which would have been a minor visual annoyance, but as it turns out I'd even forgotten to give them the `USE_UPS` flag. Fixed ASAP