### PR TITLE
Fix copy-from target of swappable storage battery

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/PKs_Rebalancing/items/vehicle_parts.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/PKs_Rebalancing/items/vehicle_parts.json
@@ -26,7 +26,7 @@
   },
   {
     "id": "storage_battery_removable",
-    "copy-from": "storage_battery",
+    "copy-from": "storage_battery_removable",
     "type": "vehicle_part",
     "name": "swappable storage battery",
     "item": "storage_battery",


### PR DESCRIPTION
The whole point of the swappable storage battery is being able to change them without tools. Without this fix the swappable battery needs a hacksaw to remove, like the regular storage battery. I'm honestly not sure if this entry is needed anymore, but at least it's not a pita anymore.