### PR TITLE
Add missing mutant eggs rot spawn (Mutant Animals)

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Mutant_Animals/items_egg.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Mutant_Animals/items_egg.json
@@ -20,30 +20,30 @@
     "flags": [ "FREEZERBURN" ],
     "rot_spawn": "GROUP_EGG_BIRD_WILD",
     "rot_spawn_chance": 50
-  },
-  {
+},
+{
     "type": "COMESTIBLE",
     "id": "egg_songbird",
-    "name": "bird egg",
+    "name": "songbird egg",
     "copy-from": "egg_bird",
     "rot_spawn": "GROUP_EGG_SONGBIRD"
-  },
-  {
+},
+{
     "type": "COMESTIBLE",
     "id": "egg_bird_mutant_vultch",
     "name": "vultch egg",
     "copy-from": "egg_bird",
     "rot_spawn": "GROUP_EGG_VULTCH"
-  },
-  {
+},
+{
     "type": "COMESTIBLE",
     "id": "egg_bird_mutant_iridescent",
     "name": "iridescent egg",
     "color": "pink",
     "copy-from": "egg_bird",
     "rot_spawn": "GROUP_EGG_IRIDESCENT"
-  },
-  {
+},
+{
     "type": "COMESTIBLE",
     "id": "egg_bird_mutant_ghoul",
     "name": "ghoul bird egg",
@@ -59,8 +59,8 @@
     "stack_size": 4,
     "fun": -50,
     "rot_spawn": "GROUP_EGG_GHOUL"
-  },
-  {
+},
+{
     "type": "COMESTIBLE",
     "id": "egg_bird_mutant_elephant",
     "volume": "1 L",
@@ -69,5 +69,5 @@
     "name": "elephant egg",
     "copy-from": "egg_bird",
     "rot_spawn": "GROUP_EGG_ELEPHANT"
-  }
+}
 ]

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Mutant_Animals/monstergroups_egg.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Mutant_Animals/monstergroups_egg.json
@@ -66,5 +66,45 @@
     "monsters": [
       { "monster": "mon_dermatik_larva", "freq": 1000, "cost_multiplier": 1 }
     ]
+  },
+  {
+    "name": "GROUP_EGG_SONGBIRD",
+    "type": "monstergroup",
+    "default": "mon_songbird",
+    "monsters": [
+      { "monster": "mon_songbird", "freq": 1000, "cost_multiplier": 1 }
+    ]
+  },
+  {
+    "name": "GROUP_EGG_VULTCH",
+    "type": "monstergroup",
+    "default":  "mon_bird_mutant_vultch",
+    "monsters": [
+      { "monster":  "mon_bird_mutant_vultch", "freq": 1000, "cost_multiplier": 1 }
+    ]
+  },
+  {
+    "name": "GROUP_EGG_IRIDESCENT",
+    "type": "monstergroup",
+    "default": "mon_bird_mutant_iridescent",
+    "monsters": [
+      { "monster": "mon_bird_mutant_iridescent", "freq": 1000, "cost_multiplier": 1 }
+    ]
+  },
+  {
+    "name": "GROUP_EGG_GHOUL",
+    "type": "monstergroup",
+    "default": "mon_bird_mutant_ghoul",
+    "monsters": [
+      { "monster": "mon_bird_mutant_ghoul", "freq": 1000, "cost_multiplier": 1 }
+    ]
+  },
+  {
+    "name": "GROUP_EGG_ELEPHANT",
+    "type": "monstergroup",
+    "default": "mon_bird_mutant_elephant",
+    "monsters": [
+      { "monster": "mon_bird_mutant_elephant", "freq": 1000, "cost_multiplier": 1 }
+    ]
   }
 ]


### PR DESCRIPTION
Each time a mutant bird tried to spawn from an egg, an error was thrown.
This is because their "rot_spawn" group didn't exist.
So I added those rot_spawn for the 5 eggs without group.

## Testing
- Spawn the eggs that were missing a group
![image](https://user-images.githubusercontent.com/71428793/203771542-f20e46cd-5b40-4004-b420-f41b3144d393.png)
- Change time with debug menu until the eggs are rotting
- Leave the area, wait a bit and come back
- They spawn
![image](https://user-images.githubusercontent.com/71428793/203771745-0104627d-27c8-4d73-ac38-56b6716c91c0.png)
