### PR TITLE
BioCo Autodoc Deconstruction Update

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/BioCo/recipes/deconstruct_override.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/BioCo/recipes/deconstruct_override.json
@@ -7,8 +7,10 @@
     "time": "1 h",
     "using": [ [ "soldering_standard", 14 ] ],
     "qualities": [
+      { "id": "HAMMER", "level": 1 },
       { "id": "SCREW", "level": 1 },
-      { "id": "BIOASSEMBLE", "level": 3 }
+      { "id": "WRENCH", "level": 1 },
+      { "id": "SAW_M", "level": 1 }
     ],
     "components": [
       [ [ "e_scrap", 30 ] ],


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "BioCo Autodoc Deconstruction Updates"

#### Purpose of change

Follows up on #135. BioCo Autodoc Cores were meant to be organically obtained from deconstruction of autodoc furniture, which didn't require any specialized tools. When my PR updated Autodocs to deconstruct into an item, it failed to account for this because I made the deconstruction recipe require BioAssembly 3, which is only obtainable by having the Bio-Assembler, which can only be crafted using the Autodoc Core which now cannot be accessed.

#### Describe the solution

Updates the Autodoc Disassembly recipe so that it requires the same tools as the Aftershock version (assumed balance since this is an Aftershock based mod)

#### Describe alternatives you've considered

- Make Autodoc disassembly give less items than the craft recipe to simulate that you are tearing it apart improperly.
Not sure whether we want to do this since the original mod had it chance based.

#### Testing

Able to disassemble the BioCo Autodoc for parts using a workshop toolbox, but not able to build it without a Bio-Assembler.