### PR TITLE
Galvanic Motor Shoes (On) were covering the whole body.

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Steampunk_mod_jm/sp_armor.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Steampunk_mod_jm/sp_armor.json
@@ -403,9 +403,9 @@
     "power_draw": 160000,
     "revert_to": "sp_mshoes_off",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s flicks off.", "target": "sp_mshoes_off" },
-    "covers": [ "head", "torso", "arms", "hands", "legs", "feet" ],
+    "covers": [ "feet" ],
     "encumbrance": 2,
-    "coverage": 80,
+    "coverage": 85,
     "material_thickness": 3,
     "magazine_well": "250 ml"
   }


### PR DESCRIPTION
Galvanic Motor Shoes (On) were covering the whole body instead of only the feet.
And coverage would decrease from 85% to 80%.

Since they're only motorized boots, changed to match the (Off) counterpart.