### PR TITLE
Revert wrong organization changes.

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Artyom_Emporium_v.1/art_weapons.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Artyom_Emporium_v.1/art_weapons.json
@@ -191,21 +191,6 @@
     "magazines": [ [ "45", [ "p220mag" ] ] ]
   },
   {
-    "id": "sig_p220stb",
-    "type": "GUN",
-    "copy-from": "sig_p220",
-    "name": { "str": "SIG P220 Scorpion", "str_pl": "SIG P220 Scorpion" },
-    "looks_like": "p226_357sig",
-    "description": "A special edition of the SIG P220, custom grips, custom finish, custom everything. All in a nice desert paint job. Even comes with a threaded barrel!",
-    "price": "194 USD",
-    "weight": "975 g",
-    "ranged_damage": { "damage_type": "bullet", "amount": 8 },
-    "dispersion": 135,
-    "sight_dispersion": 70,
-    "recoil": 125,
-    "durability": 9
-  },
-  {
     "id": "sig_p227",
     "type": "GUN",
     "copy-from": "sig_p224",
@@ -239,6 +224,21 @@
     ],
     "magazine_well": "250 ml",
     "magazines": [ [ "45", [ "p227mag" ] ] ]
+  },
+  {
+    "id": "sig_p220stb",
+    "type": "GUN",
+    "copy-from": "sig_p220",
+    "name": { "str": "SIG P220 Scorpion", "str_pl": "SIG P220 Scorpion" },
+    "looks_like": "p226_357sig",
+    "description": "A special edition of the SIG P220, custom grips, custom finish, custom everything. All in a nice desert paint job. Even comes with a threaded barrel!",
+    "price": "194 USD",
+    "weight": "975 g",
+    "ranged_damage": { "damage_type": "bullet", "amount": 8 },
+    "dispersion": 135,
+    "sight_dispersion": 70,
+    "recoil": 125,
+    "durability": 9
   },
   {
     "id": "sig_p226",

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/aaa NO blacklist/gun/7.92x33k.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/aaa NO blacklist/gun/7.92x33k.json
@@ -30,14 +30,6 @@
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ]
   },
   {
-    "id": "HMG44_auto",
-    "type": "GUN",
-    "copy-from": "stg44",
-    "name": { "str": "STG-44 (full-auto)" },
-    "description": "widely considered to be one of the first assault rifles, the STG-44 was produced in germany during the second world war and fires the proprietary 7.92 x 33 kurtz and has an effective range of 600 meters. This however is a reproduction rifle built to the original specifications. The lower receiver has been replaced with an original lower receiver.",
-    "durability": 6
-  },
-  {
     "id": "HMG44_sbr",
     "type": "GUN",
     "copy-from": "stg44",
@@ -51,14 +43,6 @@
     "durability": 6,
     "built_in_mods": [ "barrel_small" ],
     "magazines": [ [ "762", [ "stgmag762" ] ] ]
-  },
-  {
-    "id": "HMG44_sbr_auto",
-    "type": "GUN",
-    "copy-from": "HMG44_sbr",
-    "name": { "str": "STG-44 (SBR full-auto)" },
-    "description": "widely considered to be one of the first assault rifles, the STG-44 was produced in germany during the second world war and originally fired a proprietary 7.92x33 kurtz round. This however is a reproduction rifle built to the original specifications. it's been converted into an SBR and the lower receiver has been replaced with an original lower receiver",
-    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "full-auto", 5 ] ]
   },
   {
     "id": "HMG44_smol",
@@ -81,6 +65,22 @@
     "valid_mod_locations": [ [ "accessories", 4 ], [ "muzzle", 1 ], [ "mechanism", 2 ], [ "sling", 1 ] ],
     "built_in_mods": [ "barrel_small" ],
     "magazines": [ [ "223", [ "stgmag223" ] ] ]
+  },
+  {
+    "id": "HMG44_auto",
+    "type": "GUN",
+    "copy-from": "stg44",
+    "name": { "str": "STG-44 (full-auto)" },
+    "description": "widely considered to be one of the first assault rifles, the STG-44 was produced in germany during the second world war and fires the proprietary 7.92 x 33 kurtz and has an effective range of 600 meters. This however is a reproduction rifle built to the original specifications. The lower receiver has been replaced with an original lower receiver.",
+    "durability": 6
+  },
+  {
+    "id": "HMG44_sbr_auto",
+    "type": "GUN",
+    "copy-from": "HMG44_sbr",
+    "name": { "str": "STG-44 (SBR full-auto)" },
+    "description": "widely considered to be one of the first assault rifles, the STG-44 was produced in germany during the second world war and originally fired a proprietary 7.92x33 kurtz round. This however is a reproduction rifle built to the original specifications. it's been converted into an SBR and the lower receiver has been replaced with an original lower receiver",
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "full-auto", 5 ] ]
   },
   {
     "id": "HMG44_smol_auto",


### PR DESCRIPTION
When I did #150 for files prior to BL9 I reorganized the files to help me do copy-from more efficiently and forgot to change it back, this PR swaps them back to what they should be for easier maintenance.