### PR TITLE
SPECIES update

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/Archived-Mods/M_onstergroups_Combo_Patch/Monsters/missing.json
+++ b/Kenan-BrightNights-Structured-Modpack/Archived-Mods/M_onstergroups_Combo_Patch/Monsters/missing.json
@@ -2,6 +2,7 @@
   {
     "type" : "SPECIES",
     "id" : "TYRANID",
+    "name": { "str": "tyranid" },
     "description": "a tyranid",
     "anger_triggers" : [ "FRIEND_DIED", "FRIEND_ATTACKED", "PLAYER_WEAK", "STALK" ],
     "fear_triggers" : [ "HURT", "FIRE" ]	
@@ -9,6 +10,7 @@
   {
     "type" : "SPECIES",
     "id" : "ORK",
+    "name": { "str": "ork" },
     "description": "an ork",
     "anger_triggers" : [ "FRIEND_DIED", "FRIEND_ATTACKED", "PLAYER_WEAK", "STALK" ],
     "fear_triggers" : [ "HURT", "FIRE" ]

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/AdvancedGear_CDDA_Mod/definitions.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/AdvancedGear_CDDA_Mod/definitions.json
@@ -19,7 +19,8 @@
     "neutral": [ "science" ]
   },{
     "type": "SPECIES",
-    "id": "NANOTECH"
+    "id": "NANOTECH",
+    "name": { "str": "nanotech monster" }
   },{
     "type" : "material",
     "ident" : "nanite",

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Advanced_Technologies/at_species.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Advanced_Technologies/at_species.json
@@ -1,8 +1,9 @@
 [
-    {
-        "type" : "SPECIES",
-        "id" : "CYBORG",
-		"anger_triggers" : ["HURT", "FRIEND_DIED"],
-        "fear_triggers" : ["FIRE"]
-    }
+  {
+    "type" : "SPECIES",
+    "id" : "CYBORG",
+    "name": { "str": "cyborg" },
+    "anger_triggers" : ["HURT", "FRIEND_DIED"],
+    "fear_triggers" : ["FIRE"]
+  }
 ]

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Fallout_Mod_Expansion_jm/fo_species.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Fallout_Mod_Expansion_jm/fo_species.json
@@ -2,6 +2,7 @@
   {
     "type": "SPECIES",
     "id": "FO_GHOUL",
+    "name": { "str": "ghoul" },
     "description": "a ghoul",
     "footsteps": "shuffling."
   }

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Really_Dark_Skies/monsters/species.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Really_Dark_Skies/monsters/species.json
@@ -2,6 +2,7 @@
   {
     "type": "SPECIES",
     "id": "ALIEN",
+    "name": { "str": "alien" },
     "description": "an alien",
     "footsteps": "metallic footfalls",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ]
@@ -9,6 +10,7 @@
   {
     "type": "SPECIES",
     "id": "ALIENROBOT",
+    "name": { "str": "alien robot" },
     "description": "an alien robot",
     "footsteps": "booming stomps",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ]
@@ -16,6 +18,7 @@
   {
     "type": "SPECIES",
     "id": "WILDALIEN",
+    "name": { "str": "alien animal" },
     "description": "an alien animal",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "HURT", "FIRE" ]
@@ -23,6 +26,7 @@
   {
     "type": "SPECIES",
     "id": "BIOCRYSTAL",
+    "name": { "str": "fusion of flesh and mineral", "str_pl": "fusions of flesh and mineral" },
     "description": "a fusion of flesh and mineral",
     "footsteps": "shuffling and scraping.",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ],

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Youkai_Disco/youkai_factions.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/Youkai_Disco/youkai_factions.json
@@ -2,17 +2,20 @@
   {
     "type": "SPECIES",
     "id": "YOUKAI",
+    "name": { "str": "youkai" },
     "description": "Youkai",
     "fear_triggers": [ "HURT", "FRIEND_DIED" ]
   },
   {
     "type": "SPECIES",
     "id": "ORDER_SIDE",
+    "name": { "str": "Order side youkai" },
     "description": "Order side"
   },
   {
     "type": "SPECIES",
     "id": "CHAOS_SIDE",
+    "name": { "str": "Chaos side youkai" },
     "description": "Chaos side"
   },
   {

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/blazemod/species.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/blazemod/species.json
@@ -1,6 +1,7 @@
 [
   {
     "type": "SPECIES",
-    "id": "BLOB"
+    "id": "BLOB",
+    "name": { "str": "blob" }
   }
 ]

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/secronom/Modification Files/Monsters/-Essentials/secro_species.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/secronom/Modification Files/Monsters/-Essentials/secro_species.json
@@ -3,50 +3,59 @@
     "//": "Common secronom zeds such as tendril and spider zombies.",
     "type": "SPECIES",
     "id": "SECROZED_1",
+    "name": { "str": "secronom mutant" },
     "description": "a secronom mutant"
   },
   {
     "//": "Rare secronom zeds such as nautilus, nix and dissonant screamer.",
     "type": "SPECIES",
     "id": "SECROZED_2",
+    "name": { "str": "elite secronom mutant" },
     "description": "an elite secronom mutant"
   },
   {
     "//": "Exceptional secronom zeds. Titan, nocturne and final formed zed such as wraith fall to this specie.",
     "type": "SPECIES",
     "id": "SECROZED_3",
+    "name": { "str": "deadly secronom mutant" },
     "description": "a deadly secronom mutant"
   },
   {
     "//": "End-game secronom zeds. Few fall to this specie, as they are nearly impossible to kill w/o high dps weapons.",
     "type": "SPECIES",
     "id": "SECROZED_ULTIMATE",
+    "name": { "str": "catastrophic secronom mutant" },
     "description": "a catastrophic secronom mutant"
   },
   {
     "type": "SPECIES",
     "id": "SECROSPEC",
+    "name": { "str": "secronom specimen" },
     "description": "a secronom specimen"
   },
   {
     "type": "SPECIES",
     "id": "SECROWORM",
+    "name": { "str": "secronom worm mutant" },
     "description": "a secronom worm mutant"
   },
   {
     "type": "SPECIES",
     "id": "SECRODRAG",
+    "name": { "str": "cyber-dragon" },
     "description": "a cyber-dragon"
   },
   {
     "type": "SPECIES",
     "id": "SFLESH",
+    "name": { "str": "crimson horror" },
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED" ],
     "description": "a crimson horror"
   },
   {
     "type": "SPECIES",
     "id": "SSADDLER",
+    "name": { "str": "insectoid" },
     "description": "a insectoid"
   }
 ]

--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/vamp_stuff/Modification_Files/Monsters/monster_specie.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/vamp_stuff/Modification_Files/Monsters/monster_specie.json
@@ -2,17 +2,20 @@
   {
     "type": "SPECIES",
     "id": "LEECH",
+    "name": { "str": "leech", "str_pl": "leeches" },
     "anger_triggers": [ "FRIEND_DIED" ],
     "fear_triggers": [ "HURT", "FIRE" ]
   },
   {
     "type": "SPECIES",
     "id": "VAMPBAT",
+    "name": { "str": "vampire bat" },
     "anger_triggers": [ "FRIEND_DIED" ],
     "fear_triggers": [ "HURT", "FIRE" ]
   },
   {
     "type": "SPECIES",
-    "id": "ELDERZED"
+    "id": "ELDERZED",
+    "name": { "str": "elder zombie" }
   }
 ]


### PR DESCRIPTION
Related to
- cataclysmbnteam/Cataclysm-BN#2720

Adds species names with plural forms where necessary.

Isn't critical, mainly if new achievements are to be added.

Tested, wait for dependent PR before merging.