### PR TITLE
fixed and rebalanced PK's Rebalancing's bomblets

### DIFF
--- a/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/PKs_Rebalancing/items/ammo.json
+++ b/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods/PKs_Rebalancing/items/ammo.json
@@ -90,9 +90,9 @@
     "dont_recover_one_in": 9,
     "explode_in_fire": true,
     "explosion": {
-      "damage": 12,
+      "damage": 36,
       "radius": 3,
-      "fragment": { "impact": { "damage_type": "stab", "amount": 1000, "armor_multiplier": 3 }, "range": 10 }
+      "fragment": { "impact": { "damage_type": "stab", "amount": 10, "armor_multiplier": 3 }, "range": 6 }
     }
   },
   {
@@ -116,7 +116,7 @@
     "explosion": {
       "damage": 4,
       "radius": 3,
-      "fragment": { "impact": { "damage_type": "stab", "amount": 6800, "armor_multiplier": 3 }, "range": 10 }
+      "fragment": { "impact": { "damage_type": "stab", "amount": 68, "armor_multiplier": 3 }, "range": 6 }
     }
   },
   {


### PR DESCRIPTION
I've reduced the fragment range of the bomblet from 10 squares to 6 squares, as it performs too well as an AoE attack and can hurt yourself. I've also fixed the fragment damage set by DDA, and buffed the performance of the explosive bomblet, which performs relatively poorly.